### PR TITLE
Add `__init__.py` to become a regular package

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Get version number
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,9 @@ jobs:
                     - "3.11"
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies
@@ -24,6 +24,7 @@ jobs:
                   pip install vapoursynth-portable==${{ matrix.versions }}
                   pip install -r requirements.txt
                   pip install -r requirements-dev.txt
+              id: dependencies
             - name: Running flake8
               run: flake8 getfscaler
             - name: Running mypy

--- a/.github/workflows/pypipublish.yml
+++ b/.github/workflows/pypipublish.yml
@@ -9,10 +9,10 @@ jobs:
         name: Build and push to PyPI
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
 
         - name: Prep Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
             python-version: '3.11'
 

--- a/getfscaler/__main__.py
+++ b/getfscaler/__main__.py
@@ -369,7 +369,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Find the best inverse scaler for a given frame")
+    parser = argparse.ArgumentParser(prog="getfscaler", description="Find the best inverse scaler for a given frame")
 
     parser.add_argument(
         dest="input_file",


### PR DESCRIPTION
A `__init__.py` is required to be considered a "regular package" (<https://docs.python.org/3.11/glossary.html#term-regular-package>). Without this the `setuptools.find_packages()` in `setup.py` returns an empty list.

Before:

```bash
$ python -m pip install git+https://github.com/Jaded-Encoding-Thaumaturgy/getfscaler@920b4451d7968eb2ea42729600e22d7a14a3858c
$ python -m getfscaler
.venv\Scripts\python.exe: No module named getfscaler
```

After:

```bash
$ python -m pip install git+https://github.com/sgt0/getfscaler@package
$ python -m getfscaler
usage: getfscaler [-h] [--native-height NATIVE_HEIGHT] [--native_width NATIVE_WIDTH] [--crop CROP]
                  [--frame FRAME] [--field-based FIELDS] [--swap] [--extensive] [--out] [--debug]
                  input_file
getfscaler: error: the following arguments are required: input_file
```

Also set program name for argparse so it doesn't appear as `__main__.py`.

Updated a couple of the GitHub actions too while I'm here.
